### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -124,7 +124,7 @@ end
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://sciml.github.io/ColPrac/stable/)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,7 @@ using SciMLTesting, QuasiMonteCarlo, Test
 run_qa(
     QuasiMonteCarlo;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs coverage in the QA test
- update the ColPrac docs link to the hosted docs page so the existing strict docs linkcheck can pass locally

## Audit
- QuasiMonteCarlo.jl declares exported package-owned public API through export only; no Julia public declarations were found.
- Every package-owned exported name has a source docstring.
- The existing docs already render the exported public API; SciMLTesting rendered-docs QA passes after enabling the check.
- No [sources] or path entries were added.

## Validation
- git diff --check
- rendered public-docs QA with Julia +1.10: Quality Assurance 17/17
- exported-name docstring audit with Julia +1.10: missing docstrings: none
- docs build with Julia +1.10: passed; observed pre-existing Documenter warnings for non-rendered internal docstrings under warnonly, UnsafeArrays redirect, large HTML example fallbacks, and local deploy detection
- Pkg.test() with Julia +1.10: Core/core.jl 405/405 pass, QuasiMonteCarlo tests passed
- Runic v1.7.0 --check .: passed
