### PR TITLE
Use default rendered API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,7 +3,6 @@ using SciMLTesting, QuasiMonteCarlo, Test
 run_qa(
     QuasiMonteCarlo;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (


### PR DESCRIPTION
Removes the redundant `api_docs_kwargs = (; rendered = true)` override now that SciMLTesting 2.1+ performs rendered public-API documentation validation by default.

No public API documentation or package code changes.

Validation:
- `Pkg.test()` (405/405)
- `test/qa/qa.jl` (16/16)
- Runic formatting check

Ignore until reviewed by @ChrisRackauckas.