### PR TITLE
Publicize documented sampling APIs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,8 +9,8 @@ makedocs(
     sitename = "QuasiMonteCarlo.jl",
     authors = "Chris Rackauckas",
     modules = [QuasiMonteCarlo],
-    clean = true, doctest = false, linkcheck = true,
-    warnonly = [:missing_docs],
+    clean = true, doctest = true, linkcheck = true,
+    checkdocs = :exports,
     linkcheck_ignore = [
         "https://www.sciencedirect.com/science/article/pii/S0010465509003087",
         "https://artowen.su.domains/mc/qmcstuff.pdf",

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -136,6 +136,8 @@ include("RandomizedQuasiMonteCarlo/iterators.jl")
 include("precompile.jl")
 
 export SamplingAlgorithm,
+    sample,
+    generate_design_matrices,
     GridSample,
     SobolSample,
     LatinHypercubeSample,


### PR DESCRIPTION
## Summary
- make `sample` and `generate_design_matrices` public at their owning package
- enable doctests and strict exported API documentation checks

## Verification
- `julia +1.12 --project=. -e "using Pkg; Pkg.test()"` (405/405 passed)
- `julia +1.12 --project=docs -e "using Pkg; Pkg.instantiate(); include("docs/make.jl")"`
- Runic formatting

Ignore until reviewed by @ChrisRackauckas.