### PR TITLE
Make QA actually scan QuasiMonteCarloDistributionsExt

### DIFF
--- a/ext/QuasiMonteCarloDistributionsExt.jl
+++ b/ext/QuasiMonteCarloDistributionsExt.jl
@@ -9,7 +9,7 @@ sample(n::Integer, lb::T, ub::T, D::Distributions.Sampleable, T = eltype(D))
 sample(n::Integer,
     lb::T,
     ub::T,
-    D::Distributions.Sampleable) where {T <: Union{Base.AbstractVecOrTuple, Number}}
+    D::Distributions.Sampleable) where {T <: Union{AbstractVector, Tuple, Number}}
 ```
 
 Return a point set from a distribution `D`:
@@ -38,7 +38,7 @@ sample(n::Integer, d::Integer, S::Distributions.Sampleable, T = Float64)
 sample(n::Integer,
     lb::T,
     ub::T,
-    S::Distributions.Sampleable) where {T <: Union{Base.AbstractVecOrTuple, Number}}
+    S::Distributions.Sampleable) where {T <: Union{AbstractVector, Tuple, Number}}
 ```
 
 Return a QMC point set where:
@@ -56,7 +56,7 @@ function QuasiMonteCarlo.sample(
         n::Integer, lb::T, ub::T,
         S::D
     ) where {
-        T <: Union{Base.AbstractVecOrTuple, Number},
+        T <: Union{AbstractVector, Tuple, Number},
         D <: Distributions.Sampleable,
     }
     QuasiMonteCarlo._check_sequence(lb, ub, n)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -7,6 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+Distributions = "0.25"
 SafeTestsets = "0.0.1, 0.1, 1"
 SciMLTesting = "2.4"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,23 @@
 using SciMLTesting, QuasiMonteCarlo
 
-run_qa(QuasiMonteCarlo)
+# Extension modules only exist once their trigger package is loaded, and
+# ExplicitImports can only scan modules that exist, so the weakdeps have to be
+# loaded here for QuasiMonteCarloDistributionsExt to be covered by the checks.
+using Distributions
+
+# QuasiMonteCarlo (own package): an extension is part of the package, but it is
+# loaded as its own top-level module, so it does not share a `Base.moduleroot`
+# with QuasiMonteCarlo and ExplicitImports' `allow_internal_accesses` escape
+# hatch does not apply. These are QuasiMonteCarlo's own internals with no public
+# spelling, used by QuasiMonteCarloDistributionsExt to implement `sample` and
+# `DesignMatrix` for `Distributions.Sampleable`.
+ei_kwargs = (;
+    all_qualified_accesses_are_public = (;
+        ignore = (
+            :DistributionDesignMat, :ZERO_SAMPLES_MESSAGE,
+            :_check_sequence, :initialize,
+        ),
+    ),
+)
+
+run_qa(QuasiMonteCarlo; ei_kwargs)


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Problem

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module. ExplicitImports
*does* know about extensions — `_find_submodules` reads the `[extensions]` table out of
`Project.toml` and adds each one to the set of checked modules — but only if the extension
module actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep has been loaded. `test/qa/` never
loaded `Distributions`, so `QuasiMonteCarloDistributionsExt` was **not scanned at all** by
any ExplicitImports check. A green QA lane was silent about the extension rather than
clean on it.

## Change

* `test/qa/Project.toml`: add `Distributions` (same UUID as the root `[weakdeps]` entry)
  with `[compat] Distributions = "0.25"`, mirroring the root `Project.toml` bound.
* `test/qa/qa.jl`: `using Distributions` before `run_qa`, with a comment explaining why.
* `ext/QuasiMonteCarloDistributionsExt.jl`: source fix, see below.

### Coverage

| Extension | Trigger | Scanned now? |
| --- | --- | --- |
| `QuasiMonteCarloDistributionsExt` | `Distributions` | yes |

`Distributions` is the package's only weakdep, so this is 100% extension coverage. Nothing
is left out — no GPU backends, no packages needing external system libraries.

## Proof the extension is actually scanned

"QA still passes" does not prove coverage — `run_qa` emits a fixed number of `@test`s and
each ExplicitImports check folds all submodules into a single assertion, so a clean
extension produces an identical summary either way. Verified directly from the QA
environment:

```
$ julia --project=test/qa -e '
      using QuasiMonteCarlo, Distributions, SciMLTesting
      const EI = SciMLTesting.ExplicitImports
      println("get_extension => ", Base.get_extension(QuasiMonteCarlo, :QuasiMonteCarloDistributionsExt))
      for (m, _) in EI.explicit_imports(QuasiMonteCarlo); println("  ", m); end'

get_extension => QuasiMonteCarloDistributionsExt

modules scanned by explicit_imports(QuasiMonteCarlo):
  QuasiMonteCarlo
  QuasiMonteCarloDistributionsExt
```

Negative control — the same script on this branch **without** the `using Distributions`
line, i.e. what QA saw before this PR:

```
get_extension => nothing
modules scanned: Module[QuasiMonteCarlo]
```

Independently, the first QA run after adding the weakdep errored with findings whose
source locations are inside `ext/QuasiMonteCarloDistributionsExt.jl`, which is the same
proof from the other direction.

## Findings, and what was done with each

That first run produced five `all_qualified_accesses_are_public` findings:

```
Module `QuasiMonteCarloDistributionsExt` has explicit imports of names from modules in
which they are not public (i.e. exported or declared public in Julia 1.11+):
  - `AbstractVecOrTuple` is not public in `Base` ... ext/QuasiMonteCarloDistributionsExt.jl:59:25
  - `DistributionDesignMat` is not public in `QuasiMonteCarlo` ... :77:28
  - `ZERO_SAMPLES_MESSAGE` is not public in `QuasiMonteCarlo` ... :30:35
  - `_check_sequence` is not public in `QuasiMonteCarlo` ... :62:21
  - `initialize` is not public in `QuasiMonteCarlo` ... :76:25
```

### Fixed in extension source (not ignored): `Base.AbstractVecOrTuple`

`Base.AbstractVecOrTuple` is a non-public `Base` internal, and it has a public spelling
that this package already uses. `QuasiMonteCarlo.sample(n, lb, ub, S::SamplingAlgorithm)`
in `src/QuasiMonteCarlo.jl` constrains its bounds with
`T <: Union{AbstractVector, Tuple, Number}`; the extension's `Distributions.Sampleable`
method — the exact same method for a different sampler type — used
`T <: Union{Base.AbstractVecOrTuple, Number}` instead. Changed the extension to match the
main method.

This is a small widening, not just a rename. `Base.AbstractVecOrTuple` is
`Union{Tuple{Vararg{T}}, AbstractVector{<:T}} where T`, whose diagonal rule excludes
heterogeneous tuples:

```julia
julia> Tuple{Int, Float64} <: Union{Base.AbstractVecOrTuple, Number}
false

julia> Tuple{Int, Float64} <: Union{AbstractVector, Tuple, Number}
true
```

So before this PR `sample(5, (0, 0.0), (1, 2.0), Uniform())` was a `MethodError` while the
identical call with a `SamplingAlgorithm` worked. That inconsistency is now gone —
verified locally:

```
vector bounds: (2, 5)
homog tuple:   (2, 5)
hetero tuple:  (2, 5)
scalar bounds: (1, 5)
DesignMatrix:  QuasiMonteCarlo.DistributionDesignMat{Float64, Uniform{Float64}}
```

### Ignored, with justification: QuasiMonteCarlo's own internals

`DistributionDesignMat`, `ZERO_SAMPLES_MESSAGE`, `_check_sequence` and `initialize` are
**QuasiMonteCarlo's own internals**, used by QuasiMonteCarlo's own extension to implement
`sample` and `DesignMatrix` for `Distributions.Sampleable`. This is not reaching into
another package's internals, and none of the four has a public spelling.

ExplicitImports has an `allow_internal_accesses` escape hatch for exactly this, but it is
keyed on `Base.moduleroot(mod) == Base.moduleroot(accessing_from)`, and an extension is
loaded as its own top-level module, so it does not share a `moduleroot` with its parent
package and the escape hatch does not fire. These four are therefore added to the
`all_qualified_accesses_are_public` ignore tuple in `test/qa/qa.jl` with a comment
recording that reasoning.

No check was disabled, and nothing was marked `@test_broken`.

## Local results

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m17.1s
     Testing QuasiMonteCarlo tests passed
```

```
$ GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
Core/core.jl  |  405    405  13m29.8s
Test Summary:      | Pass  Total  Time
Core/public_api.jl |   14     14  1.8s
     Testing QuasiMonteCarlo tests passed
```

(Core is run here because this PR changes extension source, not only test config.)

`test/qa/Manifest.toml` is a local build artifact and is not committed.
